### PR TITLE
feat: dockerize frontend and backend with tmux split-pane logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# ── Excluded services ────────────────────────
+simulator/
+esp32_firmware/
+
+# ── Version control ──────────────────────────
+.git/
+.gitignore
+
+# ── Dependencies (reinstalled in build) ──────
+node_modules/
+
+# ── Build artifacts ──────────────────────────
+frontend/dist/
+backend/backend.exe
+backend/backend
+*.exe
+
+# ── Database (runtime volume) ────────────────
+backend/data/
+
+# ── Editor / IDE ─────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ── Misc ─────────────────────────────────────
+.env
+.env.local
+*.log
+.DS_Store
+Thumbs.db
+Desktop.ini
+docs.md
+task.md
+walkthrough.md
+issue.md
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# ============================================================
+# Stage 1: Build Go backend
+# ============================================================
+FROM golang:1.25-alpine AS backend-build
+
+WORKDIR /build
+COPY backend/ .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o backend .
+
+# ============================================================
+# Stage 2: Runtime — Node (for Vite dev server) + backend
+# ============================================================
+FROM node:22-alpine
+
+RUN apk add --no-cache tmux
+
+WORKDIR /app
+
+# -- Backend binary --
+COPY --from=backend-build /build/backend ./backend
+RUN chmod +x ./backend
+
+# -- Frontend source + deps --
+COPY frontend/package.json frontend/package-lock.json ./frontend/
+RUN cd frontend && npm ci --ignore-scripts
+COPY frontend/ ./frontend/
+
+# -- Entrypoint --
+COPY docker-entrypoint.sh .
+RUN chmod +x ./docker-entrypoint.sh
+
+# -- Data directory for SQLite --
+RUN mkdir -p ./data
+
+EXPOSE 5173 8080
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # med-reminder
 
+[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev/)
+[![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white)](https://vitejs.dev/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A local demo of a medication reminder IoT system. A caregiver monitors a
 patient via a React web app. At scheduled times, the Go backend triggers an
 IoT pill-box device over WebSocket. The device buzzes until the patient
@@ -23,6 +30,33 @@ completing the loop.
 - **SQLite** persists all state at `./backend/data/meds.db`
 
 ## Quick Start
+
+### Option 1 — Docker (Recommended)
+
+Run the frontend and backend together in a single container with split-pane logs:
+
+```bash
+# Build the image
+docker build -t sebakit .
+
+# Run with interactive tmux session
+docker run -it --rm -p 5173:5173 -p 8080:8080 sebakit
+```
+
+This opens a `tmux` session with two panes:
+- **Left pane** — Go backend logs
+- **Right pane** — Vite dev server logs
+
+> **Tip:** Use `Ctrl+B` then arrow keys to switch between tmux panes.
+> To exit, press `Ctrl+B` then `d` to detach, or `Ctrl+C` in each pane.
+
+To persist the SQLite database between runs, mount a volume:
+
+```bash
+docker run -it --rm -p 5173:5173 -p 8080:8080 -v sebakit-data:/app/data sebakit
+```
+
+### Option 2 — Manual
 
 ```bash
 # Terminal 1 — Backend
@@ -60,13 +94,19 @@ in real-time.
 | DELETE | `/api/schedules/:id`    | Delete schedule                |
 | GET    | `/api/events?days=7`    | List events (with med name)    |
 | GET    | `/api/status`           | Device connected + pending     |
+| GET    | `/api/today-status`     | Today's medication status      |
+| GET    | `/api/settings`         | Get app settings               |
+| PUT    | `/api/settings`         | Update app settings            |
 | POST   | `/api/debug/trigger`    | Fire next due immediately      |
 | WS     | `/ws/caregiver`         | Browser WebSocket              |
 | WS     | `/ws/device`            | Device WebSocket               |
 
 ## Tech Stack
 
-- **Backend:** Go 1.22+, gorilla/mux, gorilla/websocket, mattn/go-sqlite3, robfig/cron/v3
-- **Frontend:** React 18, Vite, TypeScript, Tailwind CSS v3, React Router v6, Zustand
-- **Database:** SQLite
-- **Simulator:** Standalone Go CLI
+| Layer | Technologies |
+|-------|-------------|
+| **Backend** | Go 1.25, Gin, gorilla/websocket, modernc/sqlite, robfig/cron/v3 |
+| **Frontend** | React 18, Vite 6, TypeScript, Tailwind CSS 3, React Router 6, Zustand |
+| **Database** | SQLite |
+| **Simulator** | Standalone Go CLI |
+| **DevOps** | Docker, multi-stage build, tmux |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Start a tmux session with split panes:
+#   Left  — Go backend
+#   Right — Vite dev server (frontend)
+
+tmux new-session -d -s main -n logs
+
+# Left pane: backend
+tmux send-keys -t main:logs './backend' Enter
+
+# Right pane: frontend (Vite dev server)
+tmux split-window -h -t main:logs
+tmux send-keys -t main:logs 'cd /app/frontend && npx vite --host' Enter
+
+# Attach so `docker run -it` shows the split view
+exec tmux attach -t main

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,55 @@
+# Dockerize Frontend & Backend (Lightweight Image)
+
+## Description
+
+Create a single Docker image that runs both the **frontend** (Vite/React) and the **backend** (Go/Gin) together, displaying their logs side-by-side in a split terminal view. The simulator is **excluded** from the image.
+
+## Goals
+
+- **Minimal image size** — use multi-stage builds and Alpine/scratch-based images
+- **Single container** runs both services, managed via `tmux` (or a lightweight process supervisor like `overmind`/`s6-overlay`)
+- **Split terminal output** — when attached to the container, the user sees frontend Vite logs in one pane and backend logs in another
+
+## Technical Details
+
+### Stack
+
+| Component | Tech | Port |
+|-----------|------|------|
+| Frontend | React 18 + Vite 6 + TailwindCSS 3 | `5173` |
+| Backend | Go 1.25 + Gin + SQLite (modernc) | `8080` |
+
+### Proposed Approach
+
+1. **Multi-stage Dockerfile**
+   - **Stage 1 — Frontend build**: `node:22-alpine` → `npm ci` + `npm run build` → produces `frontend/dist/`
+   - **Stage 2 — Backend build**: `golang:1.25-alpine` → `go build` with CGO disabled → produces a static binary
+   - **Stage 3 — Runtime**: `alpine:latest` (tiny base) → copy frontend dist + backend binary + install `tmux`
+
+2. **Entrypoint script** (`docker-entrypoint.sh`)
+   - Starts a `tmux` session with two panes:
+     - **Left pane**: Backend binary (`./backend`)
+     - **Right pane**: Vite dev server (`npx vite --host`) _or_ a lightweight static file server (e.g. `caddy`/`serve`) pointing at `frontend/dist/`
+   - Attaches to the tmux session so `docker run -it` shows the split view
+
+3. **`.dockerignore`**
+   - Exclude: `simulator/`, `esp32_firmware/`, `node_modules/`, `.git/`, `*.exe`, `frontend/dist/`
+
+### Dev vs Prod Mode
+
+- **Production (default)**: Frontend is pre-built (`npm run build`) and served via the Go backend or a tiny static server — no Node.js needed at runtime, smallest footprint
+- **Development (optional future flag)**: Mount source, run Vite dev server with HMR — larger image but enables live reload
+
+## Acceptance Criteria
+
+- [ ] `docker build -t sebakit .` builds successfully
+- [ ] `docker run -it sebakit` shows a tmux split with frontend & backend logs
+- [ ] Final image size is **< 100 MB** (target: ~50-80 MB)
+- [ ] Simulator code is not included in the image
+- [ ] Backend can reach its SQLite database (volume-mountable `data/` dir)
+- [ ] Frontend can reach the backend API
+- [ ] `.dockerignore` is present and correct
+
+## Labels
+
+`enhancement`, `devops`, `docker`


### PR DESCRIPTION
- Add multi-stage Dockerfile (golang:1.25-alpine → node:22-alpine)
- Add docker-entrypoint.sh with tmux split for backend + Vite logs
- Add .dockerignore excluding simulator, firmware, node_modules
- Update README with badges, Docker instructions, and refreshed tech stack